### PR TITLE
Support Companion variables in the configured file path

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -2,7 +2,7 @@
 This module will allow you to read a local file and pull the contents into a Variable.
 
 ## Configuration
-* Enter the file path.
+* Enter the file path. Companion variables are supported, for example `$(custom:file_root)/folder/file.txt`.
 * Re-Read Rate:  
   how often to re-open the file and read the contents again   
   Set to minimum 1000ms  

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.2.1",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node --test"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -44,8 +44,7 @@ module.exports = {
 				},
 			],
 			callback: async function (action) {
-				let path = await self.parseVariablesInString(action.options.path)
-				await self.readFileCustom(path, action.options.encoding, action.options.customVariable);
+				await self.readFileCustom(action.options.path, action.options.encoding, action.options.customVariable);
 			}
 		};
 
@@ -78,7 +77,7 @@ module.exports = {
 					return Promise.reject('No custom variable given for Read Specific Line')
 				}
 
-				const lineData = await self.readLine(lineNumber, `${self.config.path}`)
+				const lineData = await self.readLine(lineNumber, self.config.path)
 				self.setCustomVariableValue(action.options.customVariable, lineData)
 			}
 		};
@@ -110,8 +109,6 @@ module.exports = {
 			],
 			callback: async function (action) {
 				let line = await self.parseVariablesInString(action.options.line);
-				let path = await self.parseVariablesInString(action.options.path);
-
 				let lineNumber = parseInt(line);
 				if (isNaN(lineNumber)) {
 					self.log('error', 'Line Number must be an integer');
@@ -121,12 +118,12 @@ module.exports = {
 					self.log('error', 'No custom variable given for Read Specific Line');
 					return Promise.reject('No custom variable given for Read Specific Line')
 				}
-				if (!path) {
+				if (!action.options.path) {
 					self.log('error', 'No path given for Read Specific Line');
 					return Promise.reject('No custom variable given for Read Specific Line')
 				}
 
-				const lineData = await self.readLine(lineNumber, path)
+				const lineData = await self.readLine(lineNumber, action.options.path)
 				self.setCustomVariableValue(action.options.customVariable, lineData)
 			}
 		};

--- a/src/api.js
+++ b/src/api.js
@@ -42,6 +42,8 @@ module.exports = {
 	 */
 	async readFile(path = this.config.path, encoding = this.config.encoding) {
 		let self = this;
+		path = await self.parseVariablesInString(path);
+
 		if (self.config.verbose) {
 			self.log('debug', 'Opening File: ' + path);
 		}
@@ -120,6 +122,7 @@ module.exports = {
 	 */
 	async readLine(lineNumber, path) {
     let lineIndex = 0;
+	path = await this.parseVariablesInString(path);
 
     if (this.config?.verbose) {
         this.log('debug', 'Opening File: ' + path);

--- a/src/configFields.js
+++ b/src/configFields.js
@@ -15,6 +15,8 @@ module.exports = {
 				id: 'path',
 				width: 6,
 				label: 'File Path',
+				description: 'File path to read. Accepts Companion variables, for example $(custom:file_root)/folder/file.txt',
+				useVariables: true,
 				default: ''
 			},
 			{

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const api = require('../src/api')
+
+async function createReader(filePath) {
+	const reader = {
+		...api,
+		config: { path: '$(custom:file_path)', encoding: 'utf8', verbose: false },
+		parseVariablesInString: async (value) => value.replace('$(custom:file_path)', filePath),
+		updateStatus: () => {},
+		checkFeedbacks: () => {},
+		checkVariables: () => {},
+		stopInterval: () => {},
+	}
+
+	return reader
+}
+
+test('readFile expands Companion variables in the configured path', async () => {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'generic-filereader-'))
+	const filePath = path.join(directory, 'test.txt')
+	await fs.writeFile(filePath, 'file contents')
+
+	try {
+		const reader = await createReader(filePath)
+		const contents = await reader.readFile()
+		assert.equal(contents, 'file contents')
+	} finally {
+		await fs.rm(directory, { recursive: true, force: true })
+	}
+})
+
+test('readLine expands Companion variables in the configured path', async () => {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'generic-filereader-'))
+	const filePath = path.join(directory, 'test.txt')
+	await fs.writeFile(filePath, 'first line\nsecond line\n')
+
+	try {
+		const reader = await createReader(filePath)
+		const contents = await reader.readLine(2, reader.config.path)
+		assert.equal(contents, 'second line')
+	} finally {
+		await fs.rm(directory, { recursive: true, force: true })
+	}
+})


### PR DESCRIPTION
Fixes #14. Also covers the request in #18.

## The problem

The connection's configured path is handed straight to the filesystem, so a path
containing a variable is looked up literally. `$(custom:show_dir)/host.txt` is
treated as a directory actually named `$(custom:show_dir)`, and the connection
sits at `Connection Failure: File Does Not Exist` — exactly what #14 reports.

Two of the actions did call `parseVariablesInString`, but on their own option
rather than on the configured path, so whether variables worked depended on
which action you used. `Read Specific Line` expanded the action's path but not
the connection's.

## The change

Expansion now happens once, inside `readFile()` and `readLine()` — the single
point every caller passes through. The redundant expansion in `src/actions.js`
is removed so a path is never parsed twice, and the config field is marked
`useVariables` so the variable picker appears in the UI.

Net effect: 6 files, +60 / −9, no behaviour change for paths that contain no
variables.

## Why it matters

It lets one connection follow a path that changes at runtime, instead of needing
a separate connection per file location.

Our own use is a live show system. A show-picker button rewrites a custom
variable holding the text directory, and the same File Reader connections then
read that show's host names, captions and lower-third text. Before this change
that needed a duplicate set of connections per show; now it is one set that
follows the variable.

## Verification

- Two unit tests added, one per read path. They **fail** against the current
  code — it tries to `open` the literal string `$(custom:file_path)` — and pass
  with this change. Run with `npm test` / `yarn test`.
- `package.json` previously had the placeholder test script that always exits 1;
  it now runs `node --test`. If you would rather keep the placeholder, say so and
  I will drop that hunk.
- Running in production at our facility on a locally built module since
  2026-07-22, driving the on-air text for weekly live streams.

A companion PR, #36, fixes a polling bug that this change made easy to
hit: once a path can change at runtime it can briefly point at a file that does
not exist yet, and the current code stops polling permanently when that happens.
The two are independent and can be merged in either order, though whichever lands
second will need a trivial rebase since both touch `test/api.test.js` and
`package.json`.

## About this contribution — please read before reviewing

I am an AV and IT person, not a JavaScript developer. I hit this limitation
running a live production system, and I used Claude (an AI assistant) to write
the code and the tests and to draft this description. I am disclosing that
up front rather than letting you find out later.

What is mine: the problem, the requirement, and the production use. I needed one
File Reader connection to follow a path that changes when we switch shows. I have
been running this change on our live system since 2026-07-22 and it does what I
needed — the show-picker button redirects the readers on demand, every week.

Being straight about what I can and cannot do:

- I understand the problem and what the change does in general terms. I cannot
  defend the implementation line by line, and I am not the right person to argue
  design details.
- I can answer questions about the symptom, my environment, and the behaviour I
  see, and I can test builds on my system.
- I am not looking to take on maintenance of this module.

So please treat the diff as a starting point, not a position I am defending. If
you would rather implement it differently, do — I have no attachment to the code.
If you would rather not take AI-assisted code at all, that is a fair call and I
will not argue it; the description above should be enough to reproduce #14 and
fix it your own way. Either outcome is fine by me. I am filing this because the
fix has worked for us and I would rather share it than let the next person lose
the same time to it.

— Vern Graner, IT, Atheist Community of Austin
