### PR TITLE
Keep polling and recover after the file becomes unreadable

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ class GenericFileReaderInstance extends InstanceBase {
 			this.updateStatus(InstanceStatus.Connecting, 'Opening File...');
 			try {
 				await this.openFile();
-				this.updateStatus(InstanceStatus.Ok);
 				this.checkVariables();
 				this.checkFeedbacks();
 			} catch (error) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.2.1",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node --test"
 	},
 	"license": "MIT",
 	"dependencies": {

--- a/src/api.js
+++ b/src/api.js
@@ -6,31 +6,41 @@ const readline = require('readline');
 module.exports = {
 	async openFile() {
 		let self = this;
-		
-		const rate = self.config.rate;
 
-		try {
-			const data = await self.readFile()
-			self.filecontents = data.toString()
-	
-			if (rate > 999) {
-				if (self.config.verbose) {
-					self.log('debug', 'Creating Interval. File will be read every ' + rate + ' ms.');
-				}
-				self.INTERVAL = setInterval(async (self) => {
-					try {
-						const data = await self.readFile()
-						self.filecontents = data.toString()
-					} catch (error) {
-						// die silently
-					}
-				}, rate, self);
+		const rate = self.config.rate;
+		let readInProgress = false;
+
+		// Starting the reader again must replace the existing timer instead of
+		// creating an additional polling loop.
+		self.stopInterval();
+
+		const pollFile = async () => {
+			if (readInProgress) {
+				return;
 			}
-			else {
-				self.log('info', 'Retry Rate is 0. Module will open file one time and not read it again unless manually activated.');
+
+			readInProgress = true;
+			try {
+				const data = await self.readFile()
+				self.filecontents = data.toString()
+			} catch (error) {
+				// readFile updates the connection status. Keep the timer alive so a
+				// later path or filesystem recovery can be detected automatically.
+			} finally {
+				readInProgress = false;
 			}
-		} catch (error) {
-			self.log('error', `Can't open file: ${error}`)
+		};
+
+		await pollFile();
+
+		if (rate > 999) {
+			if (self.config.verbose) {
+				self.log('debug', 'Creating Interval. File will be read every ' + rate + ' ms.');
+			}
+			self.INTERVAL = setInterval(pollFile, rate);
+		}
+		else {
+			self.log('info', 'Retry Rate is 0. Module will open file one time and not read it again unless manually activated.');
 		}
 	},
 
@@ -58,7 +68,6 @@ module.exports = {
 					}
 
 					self.EXISTS = false;
-					self.stopInterval();
 					reject(new Error('File does not exist or is not readable: ' + path))
 
 				} else {
@@ -74,7 +83,6 @@ module.exports = {
 						if (err) {
 							self.updateStatus(InstanceStatus.BadConfig, 'Error Reading File');
 							self.log('error', 'Error reading file: ' + err);
-							self.stopInterval();
 							reject(new Error('Error reading file: ' + err))
 						}
 						else {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,77 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+const { InstanceStatus } = require('@companion-module/base')
+
+const api = require('../src/api')
+
+test('polling continues after a missing file and recovers automatically', async () => {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'generic-filereader-'))
+	const filePath = path.join(directory, 'appears-later.txt')
+	const statuses = []
+	const reader = {
+		...api,
+		config: { path: filePath, encoding: 'utf8', rate: 1000, verbose: false },
+		INTERVAL: null,
+		filecontents: '',
+		updateStatus: (...args) => statuses.push(args),
+		checkFeedbacks: () => {},
+		checkVariables: () => {},
+		log: () => {},
+	}
+
+	try {
+		await reader.openFile()
+		assert.notEqual(reader.INTERVAL, null, 'the retry interval should start after an initial failure')
+		assert.equal(statuses.at(-1)[0], InstanceStatus.ConnectionFailure)
+
+		await fs.writeFile(filePath, 'recovered contents')
+		await waitFor(() => reader.filecontents === 'recovered contents', 2500)
+
+		assert.equal(reader.EXISTS, true)
+		assert.equal(statuses.at(-1)[0], InstanceStatus.Ok)
+	} finally {
+		reader.stopInterval()
+		await fs.rm(directory, { recursive: true, force: true })
+	}
+})
+
+test('starting polling again replaces the existing interval', async () => {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'generic-filereader-'))
+	const filePath = path.join(directory, 'test.txt')
+	await fs.writeFile(filePath, 'file contents')
+	const reader = {
+		...api,
+		config: { path: filePath, encoding: 'utf8', rate: 1000, verbose: false },
+		INTERVAL: null,
+		filecontents: '',
+		updateStatus: () => {},
+		checkFeedbacks: () => {},
+		checkVariables: () => {},
+		log: () => {},
+	}
+
+	try {
+		await reader.openFile()
+		const firstInterval = reader.INTERVAL
+		await reader.openFile()
+
+		assert.notEqual(reader.INTERVAL, firstInterval)
+		assert.equal(firstInterval._destroyed, true)
+	} finally {
+		reader.stopInterval()
+		await fs.rm(directory, { recursive: true, force: true })
+	}
+})
+
+async function waitFor(predicate, timeout) {
+	const started = Date.now()
+	while (!predicate()) {
+		if (Date.now() - started >= timeout) {
+			throw new Error('Timed out waiting for condition')
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25))
+	}
+}


### PR DESCRIPTION
## Summary

If the configured file disappears or becomes unreadable, the File Reader stops
polling **permanently**. It does not recover when the file comes back. The only
cure is restarting the connection by hand.

Three defects, all in the same code path:

| | Defect | Consequence |
|---|---|---|
| 1 | `readFile()` calls `stopInterval()` on both of its error paths | A file that goes away kills the polling timer for good |
| 2 | If the file is missing at connection start, `openFile()` rejects before the timer is created | The connection never retries at all |
| 3 | `index.js` sets `InstanceStatus.Ok` unconditionally after `openFile()` | A connection that failed still shows as healthy |

Defect 3 is the one I would flag first. A File Reader can be dead and still show
green in the Connections list, so nothing tells the operator that the variables
it feeds have quietly stopped updating.

## How it was found

While developing the variable-path change in #35. Once the path
can change at runtime, it can briefly point at a file that does not exist yet —
a directory not yet populated, a share not yet mounted, a path rewritten a moment
before the file lands. That is when it became obvious the reader never came back.

To be clear about what I am claiming: I have **not** traced a specific outage on
my own system to this. It was found in testing, and the reproduction below is a
unit test rather than an incident report. The bug is present regardless of the
other PR — it only takes a file that goes missing.

## Root cause

`readFile()` is responsible for reporting connection status, and it also tears
down the caller's timer:

```js
self.EXISTS = false;
self.stopInterval();          // <-- kills the polling loop
reject(new Error('File does not exist or is not readable: ' + path))
```

The interval callback catches that rejection and comments `// die silently`, so
nothing is logged and nothing restarts the timer. `stopInterval()` also runs on
the read-error path lower down.

Separately, `openFile()` only reaches its `setInterval` call after a **successful**
first read, so a file that is missing at startup means no timer is ever created.

## The change

`openFile()` now polls through a single `pollFile()` helper. A failed read leaves
the timer running and lets `readFile()` own the status, so the next tick picks the
file up as soon as it is readable again. Starting the reader again replaces the
existing timer instead of leaking a second one, and a re-entrancy guard stops a
slow read from stacking. The two `stopInterval()` calls come out of `readFile()`;
deliberate teardown still goes through `destroy()` and the explicit
`stopInterval()` in `index.js`.

4 files, +109 / −25.

## Verification

Two unit tests, run against the current code and against the change:

| Test | Current code | With this change |
|---|---|---|
| polling continues after a missing file and recovers automatically | **fail** — `INTERVAL` is `null`, no retry timer was created | pass |
| starting polling again replaces the existing interval | **fail** — the first timer is still alive | pass |

Worth noting: on the current code the second test cannot even exit cleanly,
because the leaked interval keeps the Node process alive. That is the timer leak
made visible.

`package.json` previously had the placeholder test script that always exits 1; it
now runs `node --test`. If you would rather keep the placeholder, say so and I
will drop that hunk.

## About this contribution — please read before reviewing

I am an AV and IT person, not a JavaScript developer. I used Claude (an AI
assistant) to analyse this code path, write the fix and the tests, and draft this
description. I am disclosing that up front rather than letting you find out later.

What is mine: the production system this runs on. This change has been live on
our streaming rig since 2026-07-22 and has caused us no trouble.

Being straight about what I can and cannot do:

- I understand the problem and what the change does in general terms. I cannot
  defend the implementation line by line, and I am not the right person to argue
  design details.
- I can answer questions about the symptom, my environment, and the behaviour I
  see, and I can test builds on my system.
- I am not looking to take on maintenance of this module.

So please treat the diff as a starting point, not a position I am defending. If
you would rather implement it differently, do — I have no attachment to the code.
If you would rather not take AI-assisted code at all, that is a fair call and I
will not argue it; the analysis and the two tests above should be enough to
reproduce the failure and fix it your own way. Either outcome is fine by me. I am
filing this because it would have cost me a long time to find, and I would rather
the next person did not have to.

— Vern Graner, IT, Atheist Community of Austin
